### PR TITLE
porting on linux kernel 4.0.4

### DIFF
--- a/misc-modules/silly.c
+++ b/misc-modules/silly.c
@@ -77,7 +77,7 @@ enum silly_modes {M_8=0, M_16, M_32, M_memcpy};
 ssize_t silly_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
 	int retval;
-	int mode = iminor(filp->f_dentry->d_inode);
+	int mode = iminor(filp->f_path.dentry->d_inode);
 	void __iomem *add;
 	unsigned long isa_addr = ISA_BASE + *f_pos;
 	unsigned char *kbuf, *ptr;
@@ -159,7 +159,7 @@ ssize_t silly_write(struct file *filp, const char __user *buf, size_t count,
 		    loff_t *f_pos)
 {
 	int retval;
-	int mode = iminor(filp->f_dentry->d_inode);
+	int mode = iminor(filp->f_path.dentry->d_inode);
 	unsigned long isa_addr = ISA_BASE + *f_pos;
 	unsigned char *kbuf, *ptr;
 	void __iomem *add;

--- a/sculld/mmap.c
+++ b/sculld/mmap.c
@@ -104,7 +104,7 @@ struct vm_operations_struct sculld_vm_ops = {
 
 int sculld_mmap(struct file *filp, struct vm_area_struct *vma)
 {
-	struct inode *inode = filp->f_dentry->d_inode;
+	struct inode *inode = filp->f_path.dentry->d_inode;
 
 	/* refuse to map if order is not 0 */
 	if (sculld_devices[iminor(inode)].order)

--- a/scullp/mmap.c
+++ b/scullp/mmap.c
@@ -104,7 +104,7 @@ struct vm_operations_struct scullp_vm_ops = {
 
 int scullp_mmap(struct file *filp, struct vm_area_struct *vma)
 {
-	struct inode *inode = filp->f_dentry->d_inode;
+	struct inode *inode = filp->f_path.dentry->d_inode;
 
 	/* refuse to map if order is not 0 */
 	if (scullp_devices[iminor(inode)].order)

--- a/short/short.c
+++ b/short/short.c
@@ -188,7 +188,7 @@ ssize_t do_short_read (struct inode *inode, struct file *filp, char __user *buf,
  */
 ssize_t short_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
 {
-	return do_short_read(filp->f_dentry->d_inode, filp, buf, count, f_pos);
+	return do_short_read(filp->f_path.dentry->d_inode, filp, buf, count, f_pos);
 }
 
 
@@ -250,7 +250,7 @@ ssize_t do_short_write (struct inode *inode, struct file *filp, const char __use
 ssize_t short_write(struct file *filp, const char __user *buf, size_t count,
 		loff_t *f_pos)
 {
-	return do_short_write(filp->f_dentry->d_inode, filp, buf, count, f_pos);
+	return do_short_write(filp->f_path.dentry->d_inode, filp, buf, count, f_pos);
 }
 
 


### PR DESCRIPTION
`struct file` has no member named `f_dentry`, use `file->f_path.dentry` instead