### PR TITLE
Rename vm_fault->virtual_address to vm_fault->address (for 4.10)

### DIFF
--- a/scullc/mmap.c
+++ b/scullc/mmap.c
@@ -65,7 +65,7 @@ int scullc_vma_fault(struct vm_area_struct *vma,
 	void *pageptr = NULL; /* default to "missing" */
 
 	mutex_lock(&dev->mutex);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*

--- a/sculld/mmap.c
+++ b/sculld/mmap.c
@@ -66,7 +66,7 @@ int sculld_vma_fault(struct vm_area_struct *vma,
 	void *pageptr = NULL; /* default to "missing" */
 
 	mutex_lock(&dev->mutex);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*

--- a/scullp/mmap.c
+++ b/scullp/mmap.c
@@ -66,7 +66,7 @@ int scullp_vma_fault(struct vm_area_struct *vma,
 	void *pageptr = NULL; /* default to "missing" */
 
 	mutex_lock(&dev->mutex);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*

--- a/scullv/mmap.c
+++ b/scullv/mmap.c
@@ -66,7 +66,7 @@ int scullv_vma_fault(struct vm_area_struct *vma,
 	void *pageptr = NULL; /* default to "missing" */
 
 	mutex_lock(&dev->mutex);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*

--- a/simple/simple.c
+++ b/simple/simple.c
@@ -103,7 +103,7 @@ int simple_vma_fault(struct vm_area_struct *vma,
 {
 	struct page *pageptr;
 	unsigned long offset = vma->vm_pgoff << PAGE_SHIFT;
-	unsigned long physaddr = (unsigned long)(vmf->virtual_address - vma->vm_start) + offset;
+	unsigned long physaddr = (unsigned long)(vmf->address - vma->vm_start) + offset;
 	unsigned long pageframe = physaddr >> PAGE_SHIFT;
 
 // Eventually remove these printks


### PR DESCRIPTION
In 4.10, vm_fault 'virtual_address' changed to just 'address'